### PR TITLE
Delete extra args when instance class objects

### DIFF
--- a/purple-account.el
+++ b/purple-account.el
@@ -54,7 +54,7 @@
 (defun purple-account-init ()
   (setq purple-accounts '())
   (dolist (id (purple-call-method "PurpleAccountsGetAllActive"))
-    (let ((account (plp-account id 'id id)))
+    (let ((account (plp-account 'id id)))
       (add-to-list 'purple-accounts account t 'purple-account-eq)
       (dolist (prop purple-account-props)
 	(set-slot-value account (car prop)

--- a/purple-buddy.el
+++ b/purple-buddy.el
@@ -142,7 +142,7 @@ buffer."
 
 (defun purple-buddy-retreive-all-info (account id)
   (let ((buddy (or (purple-buddy-find 'id id)
-		   (plp-buddy id 'id id 'account account))))
+		   (plp-buddy 'id id 'account account))))
     (add-to-list 'purple-buddies buddy t 'purple-buddy-eq)
     (dolist (prop purple-buddy-props)
       (purple-buddy-retreive-info buddy (car prop) (cdr prop) :int32 id))))

--- a/purple-chat.el
+++ b/purple-chat.el
@@ -88,7 +88,7 @@
 (defun purple-chat-retreive-all-info (id)
   (let ((chat (or (purple-chat-find 'id 0)
 		  (purple-chat-find 'id id)
-		  (plp-chat id 'id id))))
+		  (plp-chat 'id id))))
     (set-slot-value chat 'id id)
     (add-to-list 'purple-chats chat t 'purple-chat-eq)
     (dolist (prop purple-chat-props)

--- a/purple-group.el
+++ b/purple-group.el
@@ -54,7 +54,7 @@
 (defun purple-group-retreive-info (node type)
   (when (= 0 type)
     (let ((group (or (purple-group-find 'node node)
-		     (purple-group node 'node node))))
+		     (purple-group 'node node))))
       (add-to-list 'purple-groups group t 'purple-group-eq)
       (purple-call-method-async "PurpleGroupGetName"
 				(curry 'set-slot-value group 'name)

--- a/purple-status.el
+++ b/purple-status.el
@@ -71,7 +71,7 @@
 
 (defun purple-status-retreive-info (id)
   (let ((status (or (purple-status-find 'id id)
-		    (plp-status id 'id id))))
+		    (plp-status 'id id))))
     (add-to-list 'purple-status status t 'purple-status-eq)
     (dolist (prop purple-status-props)
       (purple-call-method-async (cdr prop)


### PR DESCRIPTION
With the actual source code, I have "invalid slot name" for each class instance.
To use your module, I have to remove the first argument when you create an object from class:
- plp-account
- plp-buddy
- plp-chat
- purple-group
- plp-status

I don't know if it's the good way to resolve the problem on my side.

Have you this problem ?
